### PR TITLE
refactor: dockerfile uses local repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ros-humble-ros-base=0.10.0-1* \
 && rm -rf /var/lib/apt/lists/*
 WORKDIR /vsss
-RUN git clone -b feat/new_docker_image https://github.com/Ararabots-UFMS/vsss-ws23.git vsss_ws
+COPY ./vsss-ws23/ ./vsss_ws/
 WORKDIR /vsss/vsss_ws
 # requirements
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This pull request updates how the `vsss_ws` workspace is added to the Docker image. Instead of cloning the repository from GitHub, the build now copies the local `vsss-ws23` directory into the Docker image. This makes the Docker build process more reliable and ensures that local changes are included in the image.

**Docker build process update:**

* Replaced `git clone` with a `COPY` command to include the local `vsss-ws23` directory in the Docker image instead of pulling from the remote repository.