### PR TITLE
feat: add .dockerignore and fix referenced folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+build/
+install/
+log/
+__pycache__
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ros-humble-ros-base=0.10.0-1* \
 && rm -rf /var/lib/apt/lists/*
 WORKDIR /vsss
-COPY ./vsss-ws23/ ./vsss_ws/
+COPY . ./vsss_ws/
 WORKDIR /vsss/vsss_ws
 # requirements
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This pull request makes improvements to the project's Docker configuration to streamline builds and ensure a cleaner Docker image. The main changes involve updating the `.dockerignore` file to exclude unnecessary files and directories, and modifying the `Dockerfile` to copy the entire project directory instead of just a subdirectory.

Docker build optimization:

* Added a `.dockerignore` file to exclude version control files, build artifacts, logs, Python cache files, and compiled Python files from the Docker build context, which helps reduce image size and build time.
* Updated the `Dockerfile` to copy the entire project directory (`.`) into the Docker image instead of just the `vsss-ws23` subdirectory, ensuring all necessary files are included in the build.